### PR TITLE
Delete quiz attempts in chunks of 1000

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -80,8 +80,6 @@ class helper {
         for($page=0;$page<=$numpages;$page++) {
             $rs = $DB->get_recordset_select('quiz_attempts', $where, $params, '', '*', $page, $perpage);
             foreach ($rs as $attempt) {
-                $trace->output("DRY RUN: processing attempt ".$attempt->id);
-                continue;
                 $quiz = $DB->get_record('quiz', ['id' => $attempt->quiz]);
                 quiz_delete_attempt($attempt, $quiz);
                 $deleted++;


### PR DESCRIPTION
We have a pretty large database, where a need arose to delete quiz attempts that are at least a year old. When we ran the delete_attempts function, there was no output, the script just stopped after 2 seconds. Manually querying the database revealed that the script had about 750000 attempts to delete, which seems to have caused it to crash.

Modifying the loop to only hold 1000 attempts in memory at a time fixes that.